### PR TITLE
feat: switch from prisma layer to "direct" prisma integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - run: npm run dev -- -- --ci
 
       # This is what the user would do, minus actually starting the application
-      - run: cd my-sidebase-app && npx prisma generate
+      - run: cd my-sidebase-app && npx prisma db push && npx prisma generate
 
       # start app and curl from it
       - run: "cd my-sidebase-app && timeout 30 npm run dev & (sleep 10 && curl --fail localhost:3000)"

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -68,6 +68,7 @@ export const sayGoodbye = (preferences: Preferences) => {
   }
 
   if (preferences.addModules?.includes("prisma") || preferences.setStack === "cheviot") {
+    sayCommand("npx prisma db push", "Initialize the database")
     sayCommand("npx prisma generate", "Initialize the Prisma client")
   }
 

--- a/src/steps/2.addModules/moduleConfigs.ts
+++ b/src/steps/2.addModules/moduleConfigs.ts
@@ -83,7 +83,7 @@ export const resetDatabase = (databaseUrl?: string) => {
     throw new Error('This utility should not be called in production. It is meant for testing and development')
   }
 
-  execSync(\`cd ${process.cwd()} && DATABASE_URL=\${url} npx prisma db push --force-reset\`, { stdio: 'inherit' })
+  execSync(\`cd \${process.cwd()} && DATABASE_URL=\${url} npx prisma db push --force-reset\`, { stdio: 'inherit' })
 }
 `
 


### PR DESCRIPTION
This PR drops the whacky prisma-layer integration in favor of directly integrating it.

The layer implementation suffers from some shortcomings:
- setting the prisma middleware precedence requires an extra impl to mess with layer order, see: https://github.com/nuxt/framework/issues/3222#issuecomment-1345195929
- typing is broken / not correctly transpiled in some cases: https://github.com/sidebase/nuxt-prisma/issues/5
- `pnpm` problems: https://github.com/sidebase/nuxt-prisma/issues/4