### PR TITLE
feat: Enable user to choose their preferred package manager

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import { downloadTemplate, addModules, initGit, addCi, npmInstall, addReadme } f
 import { sayGoodbye, sayQuickWelcome, saySetupIsRunning, sayWelcome } from "./messages"
 import { getUserPreferences } from "./prompts"
 import { wrapInSpinner } from "./utils/spinner"
-import { getUserPkgManager } from "./utils/getUserPkgManager"
 import { cliOptions } from "./utils/parseCliOptions"
 import { count } from "./utils/count"
 
@@ -27,7 +26,7 @@ const main = async () => {
       addModules: [ "prisma", "auth", "trpc", "tailwind", "naiveui" ],
       runGitInit: true,
       addCi: "github",
-      runInstall: true
+      runInstall: 0
     }
   }
 
@@ -54,8 +53,8 @@ const main = async () => {
   }
 
   // 5. Run install
-  if (preferences.runInstall) {
-    await wrapInSpinner(`Running \`${getUserPkgManager()} install\``, npmInstall, template.dir)
+  if (preferences.runInstall !== "none") {
+    await wrapInSpinner(`Running \`${preferences.runInstall} install\``, npmInstall, preferences.runInstall, template.dir)
   }
 
   // 6. Write readme

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk"
 import type { Preferences } from "./prompts"
-import { getUserPkgManager } from "./utils/getUserPkgManager"
 import { getVersion } from "./utils/getVersion"
+import { getUserPkgManager } from "./utils/getUserPkgManager"
 
 const diamond = chalk.bold.gray("🐑 Diamond:").padEnd(12, " ")  // Make `diamond` fixed sized -> emojis can habe surprising lengths
 
@@ -62,16 +62,15 @@ export const sayGoodbye = (preferences: Preferences) => {
 
   sayCommand(`cd ${preferences.setProjectName}`, "Enter your project directory")
 
-  const packageManager = getUserPkgManager()
-  if (!preferences.runInstall) {
-    sayCommand(`${packageManager} install`, "Install project dependencies")
+  if (preferences.runInstall === "none") {
+    sayCommand(`${getUserPkgManager()} install`, "Install project dependencies")
   }
 
   if (preferences.addModules?.includes("prisma") || preferences.setStack === "cheviot") {
     sayCommand("npx prisma generate", "Initialize the Prisma client")
   }
 
-  sayCommand(`${packageManager} run dev`, "Start the development server, use CTRL+C to stop")
+  sayCommand(`${preferences.runInstall === "none" ? getUserPkgManager() : preferences.runInstall} run dev`, "Start the development server, use CTRL+C to stop")
 
   console.log(`\nStuck? Join us at ${chalk.blue("https://discord.gg/auc8eCeGzx")}\n`)
   console.log(`🐑 So Long, and Thanks for ... using ${chalk.green("sidebase")} to setup your application`)

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,7 +1,6 @@
 import prompts, { PromptType, type PromptObject } from "prompts"
 import { say } from "./messages"
 import { moduleConfigs } from "./steps/2.addModules/moduleConfigs"
-import { getUserPkgManager } from "./utils/getUserPkgManager"
 
 const skipIfCheviotWasChosen = (typeIfNotMerino: PromptType) => (_: unknown, preferences: Record<string, string>) => preferences.setStack === "cheviot" ? null : typeIfNotMerino
 
@@ -48,13 +47,16 @@ const PROMPT_QUESTIONS: PromptObject[] = [
     initial: 0,
   },
   {
-    type: "confirm",
+    type: "select",
     name: "runInstall",
-    message: () => {
-      const packageManager = getUserPkgManager()
-      return `Would you like to run \`${packageManager} install\` after finishing up?`
-    },
-    initial: true,
+    message: "Would you like to install packages after finishing up, if so choose your package manager?",
+    choices: [
+      { title: "NPM", description: "Install packages using NPM", value: "npm" },
+      { title: "YARN", description: "Install packages using YARN", value: "yarn" },
+      { title: "PNPM", description: "Install packages using PNPM", value: "pnpm" },
+      { title: "Do not install", description: "Do not install packages are project has been set up", value: "none" },
+    ],
+    initial: 0,
   }
 ]
 

--- a/src/steps/5.npmInstall.ts
+++ b/src/steps/5.npmInstall.ts
@@ -1,4 +1,3 @@
-import { getUserPkgManager } from "../utils/getUserPkgManager"
 import { execa } from "execa"
 
-export default (templateDir: string) => execa(getUserPkgManager(), ["install"], { cwd: templateDir, env: { NODE_ENV: "development" } })
+export default (packageManager: string, templateDir: string) => execa(packageManager, ["install"], { cwd: templateDir, env: { NODE_ENV: "development" } })

--- a/src/steps/6.addReadme.ts
+++ b/src/steps/6.addReadme.ts
@@ -1,7 +1,6 @@
 import { writeFile } from "node:fs/promises"
 import { getResolver } from "../getResolver"
 import { Preferences } from "../prompts"
-import { getUserPkgManager } from "../utils/getUserPkgManager"
 import { moduleConfigs, Modules } from "./2.addModules/moduleConfigs"
 
 const makeReadme = (preferences: Preferences) =>  {
@@ -32,7 +31,7 @@ const makeReadme = (preferences: Preferences) =>  {
   }
 
   const tasksPostInstall = addModules.map((module: Modules) => moduleConfigs[module].tasksPostInstall).flat()
-  const packageManager = getUserPkgManager()
+  const packageManager = preferences.runInstall === "none" ? "npm" : preferences.runInstall
 
   return `# ${setProjectName}-app
 


### PR DESCRIPTION
Enable users to choose their preferred package manager (npm, yarn, pnpm). Preview of how this looks: 

![image](https://user-images.githubusercontent.com/66737801/211082505-a993e600-d748-495b-885b-6cc83a074568.png)

Other .

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [x] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
