### PR TITLE
fix: properly indent template, proper use of single-quotes and no trailing commas from the get-go

### DIFF
--- a/src/steps/2.addModules/index.ts
+++ b/src/steps/2.addModules/index.ts
@@ -63,7 +63,7 @@ export default defineNuxtConfig(${inspect(nuxtConfig, { compact: false })})
   const moduleIndexHtmlSnippets = selectedModules.map((module) => moduleConfigs[module].htmlForIndexVue).filter(html => typeof html !== "undefined")
   const nuxtPagesIndexVue = `<template>
   <div>
-    <h1${selectedModules.includes("tailwind") ? " class=\"text-4xl\"" : ""}>Welcome to your sidebase app!</h1>${moduleIndexHtmlSnippets.length > 0 ? "\n" + moduleIndexHtmlSnippets.join("\n    ") : ""}
+    <h1${selectedModules.includes("tailwind") ? " class=\"text-4xl\"" : ""}>Welcome to your sidebase app!</h1>${moduleIndexHtmlSnippets.length > 0 ? "\n    " + moduleIndexHtmlSnippets.join("\n    ") : ""}
   </div>
 </template>
 `

--- a/src/steps/2.addModules/moduleConfigs.ts
+++ b/src/steps/2.addModules/moduleConfigs.ts
@@ -38,7 +38,7 @@ const prismaExampleEndpoint = `/**
  *   return { prisma: event.context.prisma }
  * }
  *
- * export type Context = inferAsyncReturnType<typeof createContext>;
+ * export type Context = inferAsyncReturnType<typeof createContext>
  * \`\`\`
  */
 export default defineEventHandler(event => event.context.prisma.example.findMany())
@@ -154,7 +154,7 @@ export default NuxtAuthHandler({
 const nuxtAuthExamplePage = `<template>
   <div>
     <div>I'm protected! Session data: {{ data }}</div>
-    <button @click="signOut()" class="rounded-xl shadow-xl p-2 m-2">sign out</button>
+    <button class="rounded-xl shadow-xl p-2 m-2" @click="signOut()">sign out</button>
   </div>
 </template>
 
@@ -178,7 +178,7 @@ const nuxtTrpcRootConfig = `/**
  * @see https://trpc.io/docs/v10/procedures
  */
 import { initTRPC } from '@trpc/server'
-import superjson from 'superjson';
+import superjson from 'superjson'
 import { Context } from '~/server/trpc/context'
 
 const t = initTRPC.context<Context>().create({
@@ -188,9 +188,9 @@ const t = initTRPC.context<Context>().create({
 /**
  * Unprotected procedure
  **/
-export const publicProcedure = t.procedure;
-export const router = t.router;
-export const middleware = t.middleware;
+export const publicProcedure = t.procedure
+export const router = t.router
+export const middleware = t.middleware
 `
 
 const nuxtTrpcRoutersIndex = `import { z } from 'zod'
@@ -208,7 +208,7 @@ export const appRouter = router({
         greeting: \`hello \${input?.text ?? 'world'}\`,
         time: new Date()
       }
-    }),
+    })
 })
 
 // export type definition of API
@@ -232,7 +232,7 @@ export function createContext (_event: H3Event) {
   return {}
 }
 
-export type Context = inferAsyncReturnType<typeof createContext>;
+export type Context = inferAsyncReturnType<typeof createContext>
 `
 
 const nuxtTrpcApiHandler = `import { createNuxtApiHandler } from 'trpc-nuxt'
@@ -246,9 +246,9 @@ export default createNuxtApiHandler({
 })
 `
 
-const nuxtTrpcPlugin = `import { createTRPCNuxtClient, httpBatchLink } from "trpc-nuxt/client"
-import superjson from 'superjson';
-import type { AppRouter } from "~/server/trpc/routers"
+const nuxtTrpcPlugin = `import { createTRPCNuxtClient, httpBatchLink } from 'trpc-nuxt/client'
+import superjson from 'superjson'
+import type { AppRouter } from '~/server/trpc/routers'
 
 export default defineNuxtPlugin(() => {
   /**

--- a/src/steps/2.addModules/moduleConfigs.ts
+++ b/src/steps/2.addModules/moduleConfigs.ts
@@ -152,8 +152,10 @@ export default NuxtAuthHandler({
 `
 
 const nuxtAuthExamplePage = `<template>
-  <div>I'm protected! Session data: {{ data }}</div>
-  <button @click="signOut()" class="rounded-xl shadow-xl p-2 m-2">sign out</button>
+  <div>
+    <div>I'm protected! Session data: {{ data }}</div>
+    <button @click="signOut()" class="rounded-xl shadow-xl p-2 m-2">sign out</button>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -176,11 +178,11 @@ const nuxtTrpcRootConfig = `/**
  * @see https://trpc.io/docs/v10/procedures
  */
 import { initTRPC } from '@trpc/server'
-import { Context } from '~/server/trpc/context'
 import superjson from 'superjson';
+import { Context } from '~/server/trpc/context'
 
 const t = initTRPC.context<Context>().create({
-  transformer: superjson,
+  transformer: superjson
 })
 
 /**
@@ -198,12 +200,12 @@ export const appRouter = router({
   hello: publicProcedure
     .input(
       z.object({
-        text: z.string().nullish(),
-      }),
+        text: z.string().nullish()
+      })
     )
     .query(({ input }) => {
       return {
-        greeting: \`hello \${input?.text ?? "world"}\`,
+        greeting: \`hello \${input?.text ?? 'world'}\`,
         time: new Date()
       }
     }),
@@ -220,11 +222,11 @@ import type { H3Event } from 'h3'
  * Creates context for an incoming request
  * @link https://trpc.io/docs/context
  */
-export async function createContext(event: H3Event) {
+export function createContext (_event: H3Event) {
   /**
    * Add any trpc-request context here. E.g., you could add \`prisma\` like this (if you've added it via sidebase):
    * \`\`\`ts
-   * return { prisma: event.context.prisma }
+   * return { prisma: _event.context.prisma }
    * \`\`\`
    */
   return {}
@@ -240,13 +242,13 @@ import { createContext } from '~/server/trpc/context'
 // export API handler
 export default createNuxtApiHandler({
   router: appRouter,
-  createContext,
+  createContext
 })
 `
 
 const nuxtTrpcPlugin = `import { createTRPCNuxtClient, httpBatchLink } from "trpc-nuxt/client"
-import type { AppRouter } from "~/server/trpc/routers"
 import superjson from 'superjson';
+import type { AppRouter } from "~/server/trpc/routers"
 
 export default defineNuxtPlugin(() => {
   /**
@@ -257,15 +259,15 @@ export default defineNuxtPlugin(() => {
     transformer: superjson,
     links: [
       httpBatchLink({
-        url: "/api/trpc",
-      }),
-    ],
+        url: '/api/trpc'
+      })
+    ]
   })
 
   return {
     provide: {
-      client,
-    },
+      client
+    }
   }
 })
 `


### PR DESCRIPTION
This PR:
- fixes some template indentation
- fixes some incorrect usage of double-quotes and trailing commas

so that starting experience is nicer and according to eslint-rules.
