### PR TITLE
feat: also check style & types in CI pipeline, fix template-formatting for everything that came malformatted

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,9 +23,6 @@ jobs:
       - run: npm run typecheck
 
   testCli:
-    strategy:
-      matrix:
-        pkgManager: [npm, pnpm]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -34,37 +31,29 @@ jobs:
         with:
           node-version: 16.14.2
 
-      # Setup for `pnpm` matrix-case
-      - run: npm install -g pnpm
-        if: ${{ matrix.pkgManager == 'pnpm' }}
-      - run: ${{ matrix.pkgManager }} install
-        if: ${{ matrix.pkgManager == 'pnpm' }}
+      - run: npm ci
+      - run: npm run dev -- -- --ci
 
-      # Setup for `npm` matrix-case
-      - run: ${{ matrix.pkgManager }} ci
-        if: ${{ matrix.pkgManager == 'npm' }}
 
-      # Run cli command in automatic mode
-      - run: ${{ matrix.pkgManager }} run dev -- -- --ci
 
       # This is what the user would do, minus actually starting the application
       - run: cd my-sidebase-app && npx prisma db push && npx prisma generate
 
-      # Lint and typecheck generated code - should be flawless
-      - run: ${{ matrix.pkgManager }} run lint
-      - run: ${{ matrix.pkgManager }} run typecheck
+      # code should be 100% correct at the start
+      - run: npm run lint
+      - run: npm run typecheck
 
       # start dev-app, all of the following adapted from https://stackoverflow.com/a/60996259
-      - run: "cd my-sidebase-app && timeout 30 ${{ matrix.pkgManager }} run dev || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
+      - run: "cd my-sidebase-app && timeout 30 npm run dev || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
 
       # start prod-app
-      - run: "export AUTH_ORIGIN=http://localhost:3000 && cd my-sidebase-app && ${{ matrix.pkgManager }} run build && timeout 30 ${{ matrix.pkgManager }} run preview || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
+      - run: "export AUTH_ORIGIN=http://localhost:3000 && cd my-sidebase-app && npm run build && timeout 30 npm run preview || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
 
       # start dev-app and curl from it
-      - run: "cd my-sidebase-app && timeout 30 ${{ matrix.pkgManager }} run dev & (sleep 10 && curl --fail localhost:3000) || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
+      - run: "cd my-sidebase-app && timeout 30 npm run dev & (sleep 10 && curl --fail localhost:3000) || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
 
       # build prod-app, start it in prod mode and curl from it
-      - run: "export AUTH_ORIGIN=http://localhost:3000 && cd my-sidebase-app && ${{ matrix.pkgManager }} run build && timeout 30 ${{ matrix.pkgManager }} run preview & (sleep 10 && curl --fail localhost:3000)  || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
+      - run: "export AUTH_ORIGIN=http://localhost:3000 && cd my-sidebase-app && npm run build && timeout 30 npm run preview & (sleep 10 && curl --fail localhost:3000)  || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
 
   publish:
     needs: [testCli, testCodebase]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
   testCli:
     strategy:
       matrix:
-        pkgManager: [npm, pnpm, yarn]
+        pkgManager: [npm, pnpm]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -39,14 +39,6 @@ jobs:
         if: ${{ contains(matrix.pkgManager, 'pnpm') }}
       - run: ${{ matrix.pkgManager }} install
         if: ${{ contains(matrix.pkgManager, 'pnpm') }}
-
-      # Setup for `yarn` matrix-case
-      - run: corepack enable
-        if: ${{ contains(matrix.pkgManager, 'yarn') }}
-      - run: corepack prepare yarn@3.3.1 --activate
-        if: ${{ contains(matrix.pkgManager, 'yarn') }}
-      - run: ${{ matrix.pkgManager }} install
-        if: ${{ contains(matrix.pkgManager, 'yarn') }}
 
       # Setup for `npm` matrix-case
       - run: ${{ matrix.pkgManager }} ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       # Setup for `pnpm` matrix-case
       - run: npm install -g pnpm
         if: ${{ contains(matrix.pkgManager, 'pnpm') }}
-      - run: ${{ matrix.pkgManager }} install --frozen-lockfile
+      - run: ${{ matrix.pkgManager }} install
         if: ${{ contains(matrix.pkgManager, 'pnpm') }}
 
       # Setup for `yarn` matrix-case
@@ -45,7 +45,7 @@ jobs:
         if: ${{ contains(matrix.pkgManager, 'yarn') }}
       - run: corepack prepare yarn@3.3.1 --activate
         if: ${{ contains(matrix.pkgManager, 'yarn') }}
-      - run: ${{ matrix.pkgManager }} install --frozen-lockfile
+      - run: ${{ matrix.pkgManager }} install
         if: ${{ contains(matrix.pkgManager, 'yarn') }}
 
       # Setup for `npm` matrix-case

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,25 @@ jobs:
         with:
           node-version: 16.14.2
 
+      # Setup for `pnpm` matrix-case
+      - run: npm install -g pnpm
+        if: ${{ contains(matrix.pkgManager, 'pnpm') }}
+      - run: ${{ matrix.pkgManager }} install --frozen-lockfile
+        if: ${{ contains(matrix.pkgManager, 'pnpm') }}
+
+      # Setup for `yarn` matrix-case
+      - run: corepack enable
+        if: ${{ contains(matrix.pkgManager, 'yarn') }}
+      - run: corepack prepare yarn@3.3.1 --activate
+        if: ${{ contains(matrix.pkgManager, 'yarn') }}
+      - run: ${{ matrix.pkgManager }} install --frozen-lockfile
+        if: ${{ contains(matrix.pkgManager, 'yarn') }}
+
+      # Setup for `npm` matrix-case
       - run: ${{ matrix.pkgManager }} ci
+        if: ${{ contains(matrix.pkgManager, 'npm') }}
+
+      # Run cli command in automatic mode
       - run: ${{ matrix.pkgManager }} run dev -- -- --ci
 
       # This is what the user would do, minus actually starting the application

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,12 @@ jobs:
       - run: npm ci
 
       - run: npm run lint
-
       - run: npm run typecheck
 
   testCli:
+    strategy:
+      matrix:
+        pkgManager: [npm, pnpm, yarn]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -32,23 +34,27 @@ jobs:
         with:
           node-version: 16.14.2
 
-      - run: npm ci
-      - run: npm run dev -- -- --ci
+      - run: ${{ matrix.pkgManager }} ci
+      - run: ${{ matrix.pkgManager }} run dev -- -- --ci
 
       # This is what the user would do, minus actually starting the application
       - run: cd my-sidebase-app && npx prisma db push && npx prisma generate
 
+      # Lint and typecheck generated code - should be flawless
+      - run: ${{ matrix.pkgManager }} run lint
+      - run: ${{ matrix.pkgManager }} run typecheck
+
       # start dev-app, all of the following adapted from https://stackoverflow.com/a/60996259
-      - run: "cd my-sidebase-app && timeout 30 npm run dev || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
+      - run: "cd my-sidebase-app && timeout 30 ${{ matrix.pkgManager }} run dev || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
 
       # start prod-app
-      - run: "export AUTH_ORIGIN=http://localhost:3000 && cd my-sidebase-app && npm run build && timeout 30 npm run preview || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
+      - run: "export AUTH_ORIGIN=http://localhost:3000 && cd my-sidebase-app && ${{ matrix.pkgManager }} run build && timeout 30 ${{ matrix.pkgManager }} run preview || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
 
       # start dev-app and curl from it
-      - run: "cd my-sidebase-app && timeout 30 npm run dev & (sleep 10 && curl --fail localhost:3000) || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
+      - run: "cd my-sidebase-app && timeout 30 ${{ matrix.pkgManager }} run dev & (sleep 10 && curl --fail localhost:3000) || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
 
       # build prod-app, start it in prod mode and curl from it
-      - run: "export AUTH_ORIGIN=http://localhost:3000 && cd my-sidebase-app && npm run build && timeout 30 npm run preview & (sleep 10 && curl --fail localhost:3000)  || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
+      - run: "export AUTH_ORIGIN=http://localhost:3000 && cd my-sidebase-app && ${{ matrix.pkgManager }} run build && timeout 30 ${{ matrix.pkgManager }} run preview & (sleep 10 && curl --fail localhost:3000)  || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
 
   publish:
     needs: [testCli, testCodebase]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,8 +38,8 @@ jobs:
       - run: cd my-sidebase-app && npx prisma db push && npx prisma generate
 
       # code should be 100% correct at the start
-      - run: npm run lint
-      - run: npm run typecheck
+      - run: cd my-sidebase-app && npm run lint
+      - run: cd my-sidebase-app && timeout 30 npm run dev && npm run typecheck  # we need to start nuxt here to generate `.nuxt` with tsconfig
 
       # start dev-app, all of the following adapted from https://stackoverflow.com/a/60996259
       - run: "cd my-sidebase-app && timeout 30 npm run dev || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
@@ -52,6 +52,7 @@ jobs:
 
       # build prod-app, start it in prod mode and curl from it
       - run: "export AUTH_ORIGIN=http://localhost:3000 && cd my-sidebase-app && npm run build && timeout 30 npm run preview & (sleep 10 && curl --fail localhost:3000)  || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"
+
 
   publish:
     needs: [testCli, testCodebase]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,8 +34,6 @@ jobs:
       - run: npm ci
       - run: npm run dev -- -- --ci
 
-
-
       # This is what the user would do, minus actually starting the application
       - run: cd my-sidebase-app && npx prisma db push && npx prisma generate
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,13 +36,13 @@ jobs:
 
       # Setup for `pnpm` matrix-case
       - run: npm install -g pnpm
-        if: ${{ contains(matrix.pkgManager, 'pnpm') }}
+        if: ${{ matrix.pkgManager == 'pnpm' }}
       - run: ${{ matrix.pkgManager }} install
-        if: ${{ contains(matrix.pkgManager, 'pnpm') }}
+        if: ${{ matrix.pkgManager == 'pnpm' }}
 
       # Setup for `npm` matrix-case
       - run: ${{ matrix.pkgManager }} ci
-        if: ${{ contains(matrix.pkgManager, 'npm') }}
+        if: ${{ matrix.pkgManager == 'npm' }}
 
       # Run cli command in automatic mode
       - run: ${{ matrix.pkgManager }} run dev -- -- --ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
 
       # code should be 100% correct at the start
       - run: cd my-sidebase-app && npm run lint
-      - run: cd my-sidebase-app && timeout 30 npm run dev && npm run typecheck  # we need to start nuxt here to generate `.nuxt` with tsconfig
+      - run: cd my-sidebase-app && npm exec nuxi prepare && npm run typecheck
 
       # start dev-app, all of the following adapted from https://stackoverflow.com/a/60996259
       - run: "cd my-sidebase-app && timeout 30 npm run dev || ( [[ $? -eq 124 ]] && echo \"app started and did not exit within first 30 seconds, thats good\" )"

--- a/src/steps/2.addModules/index.ts
+++ b/src/steps/2.addModules/index.ts
@@ -61,9 +61,12 @@ export default defineNuxtConfig(${inspect(nuxtConfig, { compact: false })})
 
   // 6. Write index.vue with a nice welcome message as well as links to sub-pages
   const moduleIndexHtmlSnippets = selectedModules.map((module) => moduleConfigs[module].htmlForIndexVue).filter(html => typeof html !== "undefined")
+  const moduleIndexHtml = moduleIndexHtmlSnippets.length > 0 ? "\n    " + moduleIndexHtmlSnippets.join("\n    ") : ""
   const nuxtPagesIndexVue = `<template>
   <div>
-    <h1${selectedModules.includes("tailwind") ? " class=\"text-4xl\"" : ""}>Welcome to your sidebase app!</h1>${moduleIndexHtmlSnippets.length > 0 ? "\n    " + moduleIndexHtmlSnippets.join("\n    ") : ""}
+    <h1${selectedModules.includes("tailwind") ? " class=\"text-4xl\"" : ""}>
+      Welcome to your sidebase app!
+    </h1>${moduleIndexHtml}
   </div>
 </template>
 `

--- a/src/steps/2.addModules/moduleConfigs.ts
+++ b/src/steps/2.addModules/moduleConfigs.ts
@@ -154,7 +154,9 @@ export default NuxtAuthHandler({
 const nuxtAuthExamplePage = `<template>
   <div>
     <div>I'm protected! Session data: {{ data }}</div>
-    <button class="rounded-xl shadow-xl p-2 m-2" @click="signOut()">sign out</button>
+    <button class="rounded-xl shadow-xl p-2 m-2" @click="signOut()">
+      sign out
+    </button>
   </div>
 </template>
 
@@ -344,7 +346,12 @@ export const moduleConfigs: Record<Modules, ModuleConfig> = {
       "- [ ] Prisma: Run `npx prisma db push` to sync the schema to your database after changing the schema",
       "- [ ] Prisma: Run `npx prisma generate` to re-generate the client after changing the schema"
     ],
-    htmlForIndexVue: "<p>Checkout the Prisma ORM demo page here: <nuxt-link to=\"/prisma\" class=\"underline text-blue\">Click me to test the Prisma ORM setup!</nuxt-link></p>"
+    htmlForIndexVue: `<p>
+      Checkout the Prisma ORM demo page here:
+      <nuxt-link to="/prisma" class="underline text-blue">
+        Click me to test the Prisma ORM setup!
+      </nuxt-link>
+    </p>`
   },
   "auth": {
     humanReadableName: "nuxt-auth",
@@ -370,7 +377,12 @@ export const moduleConfigs: Record<Modules, ModuleConfig> = {
       "- [ ] Auth: Configure your auth providers to the [NuxtAuthHandler](./server/api/auth/[...].ts)",
       "- [ ] Auth, optional: Enable global protection by setting `enableGlobalAppMiddleware: true` in [your nuxt.config.ts](./nuxt.config.ts). Delete the logal middleware in the [protected.vue](./pages/protected.vue) page if you do"
     ],
-    htmlForIndexVue: "<p>Checkout the page protected by `nuxt-auth` here: <nuxt-link to=\"/protected\" class=\"underline text-blue\">Click me to test the auth setup!</nuxt-link></p>"
+    htmlForIndexVue: `<p>
+      Checkout the page protected by \`nuxt-auth\` here:
+      <nuxt-link to="/protected" class="underline text-blue">
+        Click me to test the auth setup!
+      </nuxt-link>
+    </p>`
   },
   "trpc": {
     humanReadableName: "tRPC 10",
@@ -428,7 +440,12 @@ export const moduleConfigs: Record<Modules, ModuleConfig> = {
       },
     ],
     tasksPostInstall: [],
-    htmlForIndexVue: "<p>Checkout the tRPC demo page here: <nuxt-link to=\"/trpc\" class=\"underline text-blue\">Click me to test the tRPC setup!</nuxt-link></p>"
+    htmlForIndexVue: `<p>
+      Checkout the tRPC demo page here:
+      <nuxt-link to="/trpc" class="underline text-blue">
+        Click me to test the tRPC setup!
+      </nuxt-link>
+    </p>`
   },
   "tailwind": {
     humanReadableName: "Tailwind CSS",

--- a/src/steps/5.npmInstall.ts
+++ b/src/steps/5.npmInstall.ts
@@ -1,7 +1,4 @@
 import { getUserPkgManager } from "../utils/getUserPkgManager"
 import { execa } from "execa"
 
-const install = (templateDir: string) => execa(getUserPkgManager(), ["install"], { cwd: templateDir, env: { NODE_ENV: "development" } })
-const lintAndFix = (templateDir: string) => execa(getUserPkgManager(), ["run", "lint", "--", "--fix"], { cwd: templateDir, env: { NODE_ENV: "development" } })
-
-export default (templateDir: string) => install(templateDir).then(() => lintAndFix(templateDir))
+export default (templateDir: string) => execa(getUserPkgManager(), ["install"], { cwd: templateDir, env: { NODE_ENV: "development" } })

--- a/src/steps/5.npmInstall.ts
+++ b/src/steps/5.npmInstall.ts
@@ -1,4 +1,7 @@
 import { getUserPkgManager } from "../utils/getUserPkgManager"
 import { execa } from "execa"
 
-export default (templateDir: string) => execa(getUserPkgManager(), ["install"], { cwd: templateDir, env: { NODE_ENV: "development" } })
+const install = (templateDir: string) => execa(getUserPkgManager(), ["install"], { cwd: templateDir, env: { NODE_ENV: "development" } })
+const lintAndFix = (templateDir: string) => execa(getUserPkgManager(), ["run", "lint", "--", "--fix"], { cwd: templateDir, env: { NODE_ENV: "development" } })
+
+export default (templateDir: string) => install(templateDir).then(() => lintAndFix(templateDir))


### PR DESCRIPTION
This PR:
- adds CI steps to:
  - lint the `--ci` output test project
  - typecheck the `--ci` output test project
  - run all of the `--ci` checks for the package managers: `pnpm`, `npm`
- fixes templates that were broken based on above checks
