### PR TITLE
fix: workaround nuxt 3.1.2 useFetch problems, see https://github.com/nuxt/nuxt/issues/15280

### DIFF
--- a/src/steps/2.addModules/moduleConfigs.ts
+++ b/src/steps/2.addModules/moduleConfigs.ts
@@ -88,7 +88,16 @@ export const resetDatabase = (databaseUrl?: string) => {
 `
 
 const prismaExamplePage = `<script setup lang="ts">
-const { data: examples } = useFetch('/api/examples')
+/**
+ * In Nuxt 3.1.2 \`useFetch\` return types are not correctly inferred. In order to workaround this limitation, we sadly need to manually import and type a lof ot things.
+ *
+ * As soon as https://github.com/nuxt/nuxt/issues/15280 is closed and released, we can go back to just: \`const { data: examples } = useFetch('/api/examples')\`
+ * */
+import type { Ref } from 'vue'
+import { Example } from '.prisma/client';
+
+const { data } = useFetch('/api/examples')
+const examples = (data as Ref<Example[] | null>)
 </script>
 
 <template>

--- a/src/steps/2.addModules/moduleConfigs.ts
+++ b/src/steps/2.addModules/moduleConfigs.ts
@@ -94,7 +94,7 @@ const prismaExamplePage = `<script setup lang="ts">
  * As soon as https://github.com/nuxt/nuxt/issues/15280 is closed and released, we can go back to just: \`const { data: examples } = useFetch('/api/examples')\`
  * */
 import type { Ref } from 'vue'
-import { Example } from '.prisma/client';
+import { Example } from '.prisma/client'
 
 const { data } = useFetch('/api/examples')
 const examples = (data as Ref<Example[] | null>)


### PR DESCRIPTION
This PR:
- manually types example API call to avoid nuxt 3.1 `useFetch` typing issues

Read and follow nuxt/nuxt/issues/15280 for more. We can likely revert this, once nuxt/nuxt/issues/15280 has been adressed and released
