### PR TITLE
fix: use the right package manager in ci

### DIFF
--- a/src/steps/4.addCi.ts
+++ b/src/steps/4.addCi.ts
@@ -33,7 +33,28 @@ jobs:
       - name: Lint
         run: nr lint
 
-      # TODO: Add more steps here, like "nr test" as you add the tooling for it
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 16.14.2
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.14.2
+
+      - name: Setup
+        run: npm i -g @antfu/ni
+
+      - name: Install
+        run: nci
+
+      - name: Build
+        run: nr build
+
+  # TODO: Add more steps here, like "nr test" as you add the tooling for it
 `
 
 export default async (preferences: Preferences, templateDir: string) => {

--- a/src/steps/4.addCi.ts
+++ b/src/steps/4.addCi.ts
@@ -12,7 +12,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  lint:
 
     runs-on: ubuntu-latest
 
@@ -24,11 +24,16 @@ jobs:
         with:
           node-version: 16.14.2
 
-      - run: npm ci
+      - name: Setup
+        run: npm i -g @antfu/ni
 
-      - run: npm run build
+      - name: Install
+        run: nci
 
-      # TODO: Add more steps here, like "npm run lint" or "npm run test" as you add the tooling for it
+      - name: Lint
+        run: nr lint
+
+      # TODO: Add more steps here, like "nr test" as you add the tooling for it
 `
 
 export default async (preferences: Preferences, templateDir: string) => {


### PR DESCRIPTION
Currently, when using package managers other than npm, ci fails
example:
```
npm ERR! The `npm ci` command can only install with an existing package-lock.json or
npm ERR! npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or
npm ERR! later to generate a package-lock.json file, then try again.
```

This PR uses https://github.com/antfu/ni to select the appropriate package manager.