### PR TITLE
chore: bump versions

### DIFF
--- a/src/steps/2.addModules/moduleConfigs.ts
+++ b/src/steps/2.addModules/moduleConfigs.ts
@@ -359,12 +359,12 @@ export const moduleConfigs: Record<Modules, ModuleConfig> = {
     dependencies: [
       {
         name: "prisma",
-        version: "^4.11.0",
+        version: "^4.13.0",
         isDev: true
       },
       {
         name: "@prisma/client",
-        version: "^4.11.0",
+        version: "^4.13.0",
         isDev: false
       }
     ],
@@ -407,12 +407,12 @@ export const moduleConfigs: Record<Modules, ModuleConfig> = {
     dependencies: [
       {
         name: "@sidebase/nuxt-auth",
-        version: "^0.4.4",
+        version: "^0.5.0",
         isDev: true
       },
       {
         name: "next-auth",
-        version: "^4.18.8",
+        version: "^4.22.1",
         isDev: false
       }
     ],
@@ -444,23 +444,23 @@ export const moduleConfigs: Record<Modules, ModuleConfig> = {
     description: "Build end-to-end typesafe APIs in Nuxt applications. See more: https://trpc.io/",
     dependencies: [{
       name: "@trpc/server",
-      version: "^10.12.0",
+      version: "^10.25.0",
       isDev: false
     }, {
       name: "@trpc/client",
-      version: "^10.12.0",
+      version: "^10.25.0",
       isDev: false
     }, {
       name: "trpc-nuxt",
-      version: "^0.7.0",
+      version: "^0.9.0",
       isDev: false
     }, {
       name: "zod",
-      version: "^3.21.2",
+      version: "^3.21.4",
       isDev: false
     }, {
       name: "superjson",
-      version: "^1.12.2",
+      version: "^1.12.3",
       isDev: false
     }],
     nuxtConfig: {
@@ -509,7 +509,7 @@ export const moduleConfigs: Record<Modules, ModuleConfig> = {
     description: "A utility-first CSS framework packed with classes that can be composed to build any design, directly in your markup. See more: https://tailwindcss.com/",
     dependencies: [{
       name: "@nuxtjs/tailwindcss",
-      version: "^6.4.0",
+      version: "^6.6.7",
       isDev: true
     }],
     nuxtConfig: {


### PR DESCRIPTION
Contributes to update versions to the newest ones:

```
  trpc-nuxt                 ~2mo     ^0.7.0  →    ^0.9.0  ~21d                          
  @trpc/client              ~3mo   ^10.12.0  →  ^10.25.0   ~2d                          
  @trpc/server              ~3mo   ^10.12.0  →  ^10.25.0   ~2d                          
  next-auth                 ~4mo    ^4.18.8  →   ^4.22.1  ~17d                          
  @prisma/client            ~2mo    ^4.11.0  →   ^4.13.0  ~17d                          
  @nuxtjs/tailwindcss  dev  ~3mo     ^6.4.0  →    ^6.6.7   ~9d                          
  @sidebase/nuxt-auth  dev  ~2mo     ^0.4.4  →    ^0.5.0  ~21d  (0.6.0-beta.0 available)
  prisma               dev  ~2mo    ^4.11.0  →   ^4.13.0  ~17d                                                 
  zod                       ~2mo    ^3.21.2  →   ^3.21.4  ~2mo    
  ```

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [x] attached screenshots / screenshot not applicable
